### PR TITLE
automatic mentions using following list

### DIFF
--- a/twtxt.c
+++ b/twtxt.c
@@ -132,7 +132,9 @@ int main(int argc, char *argv[]) {
         timebuf[sizeof(timebuf)-1] = '\0'; /* Terminate! */
 
         /* Build the new line and write it into the file: */
-        fprintf(twtxtfile, "%s\t%s\n", timebuf, text);
+        fputs(timebuf, twtxtfile);
+        putc('\t', twtxtfile);
+        fputs(text, twtxtfile);
 
         /* Done. */
         fclose(twtxtfile);


### PR DESCRIPTION
This patch uses the list of followed feeds to automatically generate mentions when appropriate:

```json
{
	"nickname": "nick",
	"twtxtfile": "/dev/tty",
	"maxlog": 100,
	"spacing": "   ",
	"following": {
		"example": "https://example.org/tw.txt",
                "exampler": "https://exampler.re/twtxt.txt"
	}
}
```

```sh
$ twtxtc tweet "Testing @mentions @example! @"
2023-01-10T03:34:57+01:00	Testing @mentions @<example https://example.org/tw.txt>! @
$ twtxtc tweet "@example@@@exampler@example@@ex"
2023-01-10T03:36:20+01:00	@<example https://example.org/tw.txt>@@@<exampler https://exampler.re/twtxt.txt>@<example https://example.org/tw.txt>@@ex
```

I followed the coding style of existing code as closely as I could and commented every significant step.